### PR TITLE
Support regexp with elsif

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -55,6 +55,7 @@ task :genRubyCodes => GEN_DIR do
         .gsub(/^(\s*return.*unless(.*\/.*\/|[^\/]*=~).*)$/, '\1' + matchedReplacer)
         .gsub(/^(\s*nil unless(.*\/.*\/|[^\/]*=~).*)$/, '\1' + matchedReplacer)
         .gsub(/^(\s*if(.*\/.*\/|[^\/]*=~).*)$/, '\1' + matchedReplacer)
+        .gsub(/^(\s*elsif(.*\/.*\/|[^\/]*=~).*)$/, '\1' + matchedReplacer)
         .gsub(/^(\s*when \/.*\/i?)$/, '\1' + matchedReplacer)
         .gsub(/^\s*\/.*\/.*=~.*$/, '\1' + matchedReplacer)
         .gsub(/\.gsub\(.*\)\s*{/, '\0' + matchedReplacer)


### PR DESCRIPTION
#5 の問題を修正する

```ruby
elsif (/CC(B)?<=(\d+)/i =~ command)
```

上記のようなコードに対して `__last__match__1` が発行されていなかったため、Cthulhuが正常に動作していなかった。

